### PR TITLE
[bugfix] if beam_b is None, set do_ctalk False

### DIFF
--- a/beamconv/instrument.py
+++ b/beamconv/instrument.py
@@ -1702,8 +1702,11 @@ class ScanStrategy(Instrument, qp.QMap):
                                             **subchunk)
                         
                         # Save memory by not copying if no pair.
-                        do_ctalk = ctalk * bool(beam_b) * (not beam_b.dead)
-                        do_ctalk = bool(do_ctalk)
+                        if beam_b is None:
+                            do_ctalk = False
+                        else:
+                            do_ctalk = ctalk * bool(beam_b) * (not beam_b.dead)
+                            do_ctalk = bool(do_ctalk)
 
                         if do_ctalk:
                             tod_a = self.tod.copy()


### PR DESCRIPTION
I was getting an error in the cell:

    S.scan_instrument_mpi(alm, binning=False, reuse_spinmaps=True, interp=False, save_tod=True, **const_el_opts)

of `introduction.ipynb` due to `beam_b` being `None` and not having the `dead` attribute.