### PR TITLE
Draft: use ducc0.totalconvolve for convolution

### DIFF
--- a/beamconv/instrument.py
+++ b/beamconv/instrument.py
@@ -3268,15 +3268,14 @@ class ScanStrategy(Instrument, qp.QMap):
         else:
             # New behaviour.
 
-            if spinmaps['s0a0']['interpolators'] is not None:
-                if interp:
-                    theta, phi = pix[1], pix[0]
-                else:
-                    nside = hp.npix2nside(len(spinmaps['s0a0']['maps'][0]))
-                    theta, phi = hp.pix2ang(nside,pix,nest=False)
-                psi = pa
+            if interp:
+                theta, phi = pix[1], pix[0]
+            else:
+                nside = hp.npix2nside(len(spinmaps['s0a0']['maps'][0]))
+                theta, phi = hp.pix2ang(nside,pix,nest=False)
+            psi = pa
 
-            tod_c += spinmaps['s2a4']['interpolators'].interpol(theta, phi, psi)
+            tod_c = spinmaps['s2a4']['interpolators'].interpol(theta, phi, psi)
 
             # Modulate by HWP angle and polarization angle.
             expm2 = np.exp(1j * (4 * hwp_ang + 2 * np.radians(polang)))
@@ -3284,23 +3283,13 @@ class ScanStrategy(Instrument, qp.QMap):
 
             tod = np.real(tod_c).copy()
 
-            tod_c *= 0.
-            # self._scan_modulate_pa(tod_c, pix, pa,
-                                   # spinmaps['s2a2']['maps'],
-                                   # spinmaps['s2a2']['s_vals'],
-                                   # reality=False, interp=interp)
-            tod_c += spinmaps['s2a2']['interpolators'].interpol(theta, phi, psi)
+            tod_c = spinmaps['s2a2']['interpolators'].interpol(theta, phi, psi)
 
             expm2 = np.exp(1j * (2 * hwp_ang))
             tod_c *= expm2
             tod += np.real(tod_c)
 
-            tod_c *= 0
-            # self._scan_modulate_pa(tod_c, pix, pa,
-                                   # spinmaps['s2a0']['maps'],
-                                   # spinmaps['s2a0']['s_vals'],
-                                   # reality=False, interp=interp)
-            tod_c += spinmaps['s2a0']['interpolators'].interpol(theta, phi, psi)
+            tod_c = spinmaps['s2a0']['interpolators'].interpol(theta, phi, psi)
 
             tod += np.real(tod_c)
             del tod_c
@@ -3700,12 +3689,16 @@ class ScanStrategy(Instrument, qp.QMap):
             # Minus sign is because eb2spin applied to alm_I results in (-1) alm_I.
             spinmap_dict['s0a2']['maps'] = ScanStrategy._spinmaps_complex(
                 -alm[0], alm[0] * 0, blmE, blmB, spin_values_s0a2, nside)
+            spinmap_dict['s0a2']['interpolators0'] = totalconvolve.Interpolator_complex(
+                -alm[0], alm[0]*0, blmE, blmB, lmax, 0 if symmetric else max_spin)
 
             if input_v:
                 blmm2, blmp2 = ScanStrategy.blmxhwp(blm, hwp_spin, 's0a2_v')
                 blmE, blmB = tools.spin2eb(blmp2, blmm2)
                 spinmap_dict['s0a2']['maps'] += ScanStrategy._spinmaps_complex(
                     -alm[3], alm[3] * 0, blmE, blmB, spin_values_s0a2, nside)
+                spinmap_dict['s0a2']['interpolators3'] = totalconvolve.Interpolator_complex(
+                    -alm[3], alm[3]*0, blmE, blmB, lmax, 0 if symmetric else max_spin)
             spinmap_dict['s0a2']['s_vals'] = spin_values_s0a2
 
             # s2a2.

--- a/beamconv/instrument.py
+++ b/beamconv/instrument.py
@@ -3274,7 +3274,7 @@ class ScanStrategy(Instrument, qp.QMap):
                 else:
                     nside = hp.npix2nside(len(spinmaps['s0a0']['maps'][0]))
                     theta, phi = hp.pix2ang(nside,pix,nest=False)
-                psi = pa  # FIXME: np.radians(pa)?
+                psi = pa
 
             tod_c += spinmaps['s2a4']['interpolators'].interpol(theta, phi, psi)
 
@@ -3899,7 +3899,7 @@ class ScanStrategy(Instrument, qp.QMap):
             if s == 0: # Scalar transform.
 
                 flms = hp.almxfl(alm, bell, inplace=False)
-                func[sidx,:] = hp.alm2map(flms, nside, verbose=False)
+                func[sidx,:] = hp.alm2map(flms, nside)
 
             else: # Spin transforms.
 
@@ -3982,8 +3982,8 @@ class ScanStrategy(Instrument, qp.QMap):
 
             if s == 0:
                 # The (-1) factor for spin 0 is explained in HEALPix doc.
-                spinmaps = [hp.alm2map(-ps_flm_p, nside, verbose=False),
-                            hp.alm2map(ms_flm_m, nside, verbose=False)]
+                spinmaps = [hp.alm2map(-ps_flm_p, nside),
+                            hp.alm2map(ms_flm_m, nside)]
                 func_c[sidx,:] = spinmaps[0] + 1j * spinmaps[1]
 
             if s > 0:

--- a/beamconv/instrument.py
+++ b/beamconv/instrument.py
@@ -3214,11 +3214,7 @@ class ScanStrategy(Instrument, qp.QMap):
             # Convert qpoint output to input healpy (in-place),
             # needed for interpolation later.
             tools.radec2colatlong(ra, dec)
-            import matplotlib.pyplot as plt
-            plt.plot(ra)
-            plt.show()
-            plt.plot(dec)
-            plt.show()
+
         else:
             # In no interpolation is required, we can go straight
             # from quaternion to pix and pa.
@@ -3353,10 +3349,6 @@ class ScanStrategy(Instrument, qp.QMap):
                                     
             # Normal unpolarized part.
             if spinmaps['s0a0']['interpolators'] is not None:
-                print("Interpolator found!")
-                print("nspinmaps: ",  len(spinmaps['s0a0']['maps']))
-                print(spinmaps['s0a0']['s_vals'])
-                pa[()]=0.
                 if interp:
                     ptg = np.zeros((pix[0].shape[0], 3))
                     ptg[:, 0] = pix[1]
@@ -3368,26 +3360,8 @@ class ScanStrategy(Instrument, qp.QMap):
                     tptg = hp.pix2ang(nside,pix,nest=False)
                     ptg[:, 0] = tptg[0]
                     ptg[:, 1] = tptg[1]
-                ptg[:, 2] = np.pi
-                print(pa)
-                print(np.min(pa), np.max(pa))
-                tmp = spinmaps['s0a0']['interpolators'].interpol(ptg)
-                tod += 2*tmp[0]
-                xtmp = tod.copy()*0
-                self._scan_modulate_pa(xtmp, pix, pa,
-                                   spinmaps['s0a0']['maps'],
-                                   spinmaps['s0a0']['s_vals'],
-                                   reality=True, interp=interp)
-                import matplotlib.pyplot as plt
-  #              xtmp -= np.mean(xtmp)
-  #              tmp[0] -= np.mean(tmp[0])
-  #              tmp[0] *= np.max(xtmp)/np.max(tmp[0])
-                plt.plot(xtmp)
-                plt.plot(2*tmp[0])
-  #              plt.plot(ptg[:,0])
-  #              plt.plot(ptg[:,1])
-                plt.show()
-                print("blaaah",xtmp-2*tmp[0])
+                ptg[:, 2] = pa  # FIXME: np.radians(pa)?
+                tod += spinmaps['s0a0']['interpolators'].interpol(ptg)[0]
             else:
                 self._scan_modulate_pa(tod, pix, pa,
                                    spinmaps['s0a0']['maps'],
@@ -3714,15 +3688,20 @@ class ScanStrategy(Instrument, qp.QMap):
                                                     beam_v=beam_v)
                 spinmap_dict['s0a0']['maps'] += ScanStrategy._spinmaps_real(
                     alm[3], blm_s0a0_v, spin_values_unpol, nside)
-                t_slm = np.array([alm[0],alm[3]])
-                t_blm = np.array([blm_s0a0[:nblm],blm_s0a0_v[:nblm]])
+                t_slm = np.array([alm[0].copy(),alm[3].copy()])
+                t_blm = np.array([blm_s0a0[:nblm].copy(),blm_s0a0_v[:nblm].copy()])
                 del blm_s0a0_v
             else:
-                t_slm = np.array([alm[0]])
-                t_blm = np.array([blm_s0a0[:nblm]])
+                t_slm = np.array([alm[0].copy()])
+                t_blm = np.array([blm_s0a0[:nblm].copy()])
 
+            lfac = np.sqrt((1.+2*np.arange(lmax+1.))/(4*np.pi))
+            ofs=0
+            for m in range(xspin+1):
+                t_blm[:, ofs:ofs+lmax+1-m] *= lfac[m:].reshape((1,-1))
+                ofs += lmax+1-m
             spinmap_dict['s0a0']['interpolators'] = ducc0.totalconvolve.Interpolator(
-                t_slm.copy(), t_blm.copy(), False, lmax, xspin, 1e-6, 2., 1)
+                t_slm, t_blm, False, lmax, xspin, 1e-11, 2., 1)
 
             spinmap_dict['s0a0']['s_vals'] = spin_values_unpol
             del blm_s0a0

--- a/beamconv/instrument.py
+++ b/beamconv/instrument.py
@@ -3268,6 +3268,7 @@ class ScanStrategy(Instrument, qp.QMap):
         else:
             # New behaviour.
 
+            # obtain theta, phi, psi pointings
             if interp:
                 theta, phi = pix[1], pix[0]
             else:

--- a/beamconv/test.py
+++ b/beamconv/test.py
@@ -122,8 +122,8 @@ def scan_bicep(lmax=700, mmax=5, fwhm=43, ra0=-10, dec0=-57.5,
 
         # plot smoothed input maps
         nside = hp.get_nside(maps[0])
-        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.), verbose=False)
-        maps_raw = hp.alm2map(alm, nside, verbose=False)
+        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.))
+        maps_raw = hp.alm2map(alm, nside)
 
         plot_iqu(maps_raw, img_out_path, 'raw_bicep',
                  sym_limits=[250, 5, 5],
@@ -265,8 +265,8 @@ def scan_atacama(lmax=700, mmax=5, fwhm=40,
 
         # plot smoothed input maps
         nside = hp.get_nside(maps[0])
-        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.), verbose=False)
-        maps_raw = hp.alm2map(alm, nside, verbose=False)
+        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.))
+        maps_raw = hp.alm2map(alm, nside)
 
         plot_iqu(maps_raw, img_out_path, 'raw_atacama',
                  sym_limits=[250, 5, 5],
@@ -925,8 +925,8 @@ def test_ghosts(lmax=700, mmax=5, fwhm=43, ra0=-10, dec0=-57.5,
 
         # plot smoothed input maps
         nside = hp.get_nside(maps[0])
-        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.), verbose=False)
-        maps_raw = hp.alm2map(alm, nside, verbose=False)
+        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.))
+        maps_raw = hp.alm2map(alm, nside)
 
         plot_iqu(maps_raw, '../scratch/img/', 'raw_ghost',
                  sym_limits=[250, 5, 5],
@@ -1162,8 +1162,8 @@ def idea_jon():
 
     # plot smoothed input maps
     nside = hp.get_nside(maps_g[0])
-    hp.smoothalm(alm, fwhm=np.radians(fwhm/60.), verbose=False)
-    maps_raw = hp.alm2map(alm, nside, verbose=False)
+    hp.smoothalm(alm, fwhm=np.radians(fwhm/60.))
+    maps_raw = hp.alm2map(alm, nside)
 
     plot_iqu(maps_raw, '../scratch/img/', 'raw_delta',
              sym_limits=[1, 1, 1],
@@ -1334,8 +1334,8 @@ def test_satellite_scan(lmax=700, mmax=2, fwhm=43,
 
         # plot smoothed input maps
         nside = hp.get_nside(maps[0])
-        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.), verbose=False)
-        maps_raw = hp.alm2map(alm, nside, verbose=False)
+        hp.smoothalm(alm, fwhm=np.radians(fwhm/60.))
+        maps_raw = hp.alm2map(alm, nside)
 
         plot_iqu(maps_raw, '../scratch/img/', 'raw_satellite',
                  sym_limits=[250, 5, 5],

--- a/beamconv/totalconvolve.py
+++ b/beamconv/totalconvolve.py
@@ -1,0 +1,58 @@
+import ducc0.totalconvolve
+import numpy as np
+
+
+def _convert_blm(blm_in, lmax, kmax):
+    nblm = ((kmax+1)*(kmax+2))//2 + (kmax+1)*(lmax-kmax)
+    blm = np.array([x[:nblm].copy() for x in blm_in])
+    lfac = np.sqrt((1.+2*np.arange(lmax+1.))/(4*np.pi))
+    ofs=0
+    for m in range(kmax+1):
+       blm[:, ofs:ofs+lmax+1-m] *= lfac[m:].reshape((1,-1))
+       ofs += lmax+1-m
+    return blm
+def _convert_blm2(blm_in, lmax, kmax):
+    nblm = ((kmax+1)*(kmax+2))//2 + (kmax+1)*(lmax-kmax)
+    blm = blm_in.copy()
+    lfac = np.sqrt((1.+2*np.arange(lmax+1.))/(4*np.pi))
+    ofs=0
+    for m in range(kmax+1):
+       blm[:, ofs:ofs+lmax+1-m] = (-1)**m * np.conj(blm[:, ofs:ofs+lmax+1-m])
+       ofs += lmax+1-m
+    blm= blm[-1::-1]
+    return blm
+
+
+class Interpolator_real:
+    def __init__(self, slm, blm, lmax, kmax, epsilon=1e-11, nthreads=1):
+        _slm = np.array([x.copy() for x in slm])
+        _blm = _convert_blm(blm, lmax, kmax)
+        self._inter = ducc0.totalconvolve.Interpolator(
+            _slm, _blm, False, lmax, kmax, epsilon, 2., nthreads)
+
+    def interpol(self, theta, phi, psi):
+        ptg = np.zeros((theta.shape[0], 3))
+        ptg[:, 0] = theta
+        ptg[:, 1] = phi
+        ptg[:, 2] = psi
+        return self._inter.interpol(ptg)[0]
+
+
+class Interpolator_complex:
+    def __init__(self, slmE, slmB, blmE, blmB, lmax, kmax, epsilon=1e-11, nthreads=1):
+        _slm = np.array([slmE, slmB])
+        _blm = _convert_blm([blmE, blmB], lmax, kmax)
+        self._inter = ducc0.totalconvolve.Interpolator(
+            _slm, _blm, False, lmax, kmax, epsilon, 2., nthreads)
+        _blm2 = _convert_blm2(_blm, lmax, kmax)
+        self._inter2 = ducc0.totalconvolve.Interpolator(
+            _slm, _blm2, False, lmax, kmax, epsilon, 2., nthreads)
+
+    def interpol(self, theta, phi, psi):
+        ptg = np.zeros((theta.shape[0], 3))
+        ptg[:, 0] = theta
+        ptg[:, 1] = phi
+        ptg[:, 2] = psi
+        res = self._inter.interpol(ptg)
+        res2 = self._inter2.interpol(ptg)
+        return res[0]+1j*res2[0]

--- a/tests/test_scan_strategy.py
+++ b/tests/test_scan_strategy.py
@@ -156,7 +156,7 @@ class TestTools(unittest.TestCase):
         # Since we have a infinitely narrow Gaussian the convolved
         # maps should just match the input (up to healpix quadrature
         # wonkyness).
-        input_map = hp.alm2map(self.alm, nside, verbose=False) # I, Q, U
+        input_map = hp.alm2map(self.alm, nside) # I, Q, U
         zero_map = np.zeros_like(input_map[0])
         np.testing.assert_array_almost_equal(input_map[0],
                                              func[0], decimal=6)
@@ -264,7 +264,7 @@ class TestTools(unittest.TestCase):
 
         # Construct TOD manually.
         polang = beam.polang
-        maps_sm = np.asarray(hp.alm2map(self.alm, nside, verbose=False,
+        maps_sm = np.asarray(hp.alm2map(self.alm, nside,
                                         fwhm=np.radians(beam.fwhm / 60.)))
 
         np.testing.assert_almost_equal(maps_sm[0],
@@ -346,7 +346,7 @@ class TestTools(unittest.TestCase):
 
         # Construct TOD manually.
         polang = beam.polang
-        maps_sm = np.asarray(hp.alm2map(alm, nside, verbose=False,
+        maps_sm = np.asarray(hp.alm2map(alm, nside,
                                         fwhm=np.radians(beam.fwhm / 60.)))
 
         np.testing.assert_almost_equal(maps_sm[0],
@@ -407,9 +407,8 @@ class TestTools(unittest.TestCase):
         # Solve for the maps.
         maps, cond = scs.solve_for_map(fill=np.nan)
 
-        alm = hp.smoothalm(self.alm, fwhm=np.radians(fwhm/60.),
-                     verbose=False)
-        maps_raw = np.asarray(hp.alm2map(self.alm, nside, verbose=False))
+        alm = hp.smoothalm(self.alm, fwhm=np.radians(fwhm/60.))
+        maps_raw = np.asarray(hp.alm2map(self.alm, nside))
 
         cond[~np.isfinite(cond)] = 10
 
@@ -1256,7 +1255,7 @@ class TestTools(unittest.TestCase):
 
         # Construct TOD manually.
         polang = beam.polang
-        maps_sm = np.asarray(hp.alm2map(self.alm, nside, verbose=False,
+        maps_sm = np.asarray(hp.alm2map(self.alm, nside,
                                         fwhm=np.radians(beam.fwhm / 60.)))
 
         np.testing.assert_almost_equal(maps_sm[0],
@@ -1326,9 +1325,8 @@ class TestTools(unittest.TestCase):
         # Solve for the maps.
         maps, cond = scs.solve_for_map(fill=np.nan)
 
-        alm = hp.smoothalm(self.alm, fwhm=np.radians(fwhm/60.),
-                     verbose=False)
-        maps_raw = np.asarray(hp.alm2map(self.alm, nside, verbose=False))
+        alm = hp.smoothalm(self.alm, fwhm=np.radians(fwhm/60.))
+        maps_raw = np.asarray(hp.alm2map(self.alm, nside))
 
         cond[~np.isfinite(cond)] = 10
 

--- a/tests/test_scan_strategy.py
+++ b/tests/test_scan_strategy.py
@@ -25,9 +25,12 @@ class TestTools(unittest.TestCase):
             alm += 1j * np.random.randn(hp.Alm.getsize(lmax))
             # Make m=0 modes real.
             alm[:lmax+1] = np.real(alm[:lmax+1])
+#            alm[:] = 0
+            alm[0]= 0
             return alm
 
         cls.alm = tuple([rand_alm(lmax) for i in range(3)])
+        cls.alm = (cls.alm[0], cls.alm[1]*0, cls.alm[2]*0)
         cls.lmax = lmax
 
     def test_init(self):
@@ -243,8 +246,10 @@ class TestTools(unittest.TestCase):
         tod = scs.scan(beam, return_tod=True, **chunk)
         self.assertEqual(tod.size, chunk['end'] - chunk['start'])
 
+        print("gnampfx")
         pix, nside_out, pa, hwp_ang = scs.scan(beam, return_point=True,
                                            **chunk)
+        print("gnampfy")
         self.assertEqual(pix.size, tod.size)
         self.assertEqual(nside, nside_out)
         self.assertEqual(pa.size, tod.size)
@@ -253,8 +258,10 @@ class TestTools(unittest.TestCase):
         # Turn on HWP
         scs.set_hwp_mod(mode='continuous', freq=1., start_ang=0)
         scs.rotate_hwp(**chunk)
+        print("gnampf1")
         tod2, pix2, nside_out2, pa2, hwp_ang2 = scs.scan(beam,
                         return_tod=True, return_point=True, **chunk)
+        print("gnampf2")
         np.testing.assert_almost_equal(pix, pix2)
         np.testing.assert_almost_equal(pix, pix2)
         np.testing.assert_almost_equal(pa, pa2)
@@ -1218,11 +1225,12 @@ class TestTools(unittest.TestCase):
         mmax = 2
         ra0=-10
         dec0=-57.5
-        fwhm = 200
-        nside = 128
+        fwhm = 0
+        nside = 1024
         az_throw = 10
-        polang = 20.
+        polang = 0.
 
+        print("Start")
         ces_opts = dict(ra0=ra0, dec0=dec0, az_throw=az_throw,
                         scan_speed=2.)
 
@@ -1233,10 +1241,11 @@ class TestTools(unittest.TestCase):
                                lmax=self.lmax, fwhm=fwhm,
                                polang=polang)
         beam = scs.beams[0][0]
+        print(beam)
         hwp_mueller = np.asarray([[1, 0, 0, 0],
-                                  [0, 1, 0, 0],
-                                  [0, 0, -1, 0],
-                                  [0, 0, 0, -1]])
+                                  [0, 0, 0, 0],
+                                  [0, 0, 0, 0],
+                                  [0, 0, 0, 0]])
         beam.hwp_mueller = hwp_mueller
         scs.init_detpair(self.alm, beam, nside_spin=nside,
                                    max_spin=mmax)
@@ -1251,8 +1260,10 @@ class TestTools(unittest.TestCase):
         # Turn on HWP
         scs.set_hwp_mod(mode='continuous', freq=1., start_ang=0)
         scs.rotate_hwp(**chunk)
+        print("Knampf1")
         tod, pix, nside_out, pa, hwp_ang = scs.scan(beam,
-                        return_tod=True, return_point=True, **chunk)
+                        return_tod=True, return_point=True, interp=True,  **chunk)
+        print("Knampf2")
 
         # Construct TOD manually.
         polang = beam.polang

--- a/tests/test_scan_strategy.py
+++ b/tests/test_scan_strategy.py
@@ -25,12 +25,9 @@ class TestTools(unittest.TestCase):
             alm += 1j * np.random.randn(hp.Alm.getsize(lmax))
             # Make m=0 modes real.
             alm[:lmax+1] = np.real(alm[:lmax+1])
-#            alm[:] = 0
-            alm[0]= 0
             return alm
 
         cls.alm = tuple([rand_alm(lmax) for i in range(3)])
-        cls.alm = (cls.alm[0], cls.alm[1]*0, cls.alm[2]*0)
         cls.lmax = lmax
 
     def test_init(self):
@@ -246,10 +243,8 @@ class TestTools(unittest.TestCase):
         tod = scs.scan(beam, return_tod=True, **chunk)
         self.assertEqual(tod.size, chunk['end'] - chunk['start'])
 
-        print("gnampfx")
         pix, nside_out, pa, hwp_ang = scs.scan(beam, return_point=True,
                                            **chunk)
-        print("gnampfy")
         self.assertEqual(pix.size, tod.size)
         self.assertEqual(nside, nside_out)
         self.assertEqual(pa.size, tod.size)
@@ -258,10 +253,8 @@ class TestTools(unittest.TestCase):
         # Turn on HWP
         scs.set_hwp_mod(mode='continuous', freq=1., start_ang=0)
         scs.rotate_hwp(**chunk)
-        print("gnampf1")
         tod2, pix2, nside_out2, pa2, hwp_ang2 = scs.scan(beam,
                         return_tod=True, return_point=True, **chunk)
-        print("gnampf2")
         np.testing.assert_almost_equal(pix, pix2)
         np.testing.assert_almost_equal(pix, pix2)
         np.testing.assert_almost_equal(pa, pa2)
@@ -1225,12 +1218,11 @@ class TestTools(unittest.TestCase):
         mmax = 2
         ra0=-10
         dec0=-57.5
-        fwhm = 0
-        nside = 1024
+        fwhm = 200
+        nside = 128
         az_throw = 10
-        polang = 0.
+        polang = 20.
 
-        print("Start")
         ces_opts = dict(ra0=ra0, dec0=dec0, az_throw=az_throw,
                         scan_speed=2.)
 
@@ -1241,11 +1233,10 @@ class TestTools(unittest.TestCase):
                                lmax=self.lmax, fwhm=fwhm,
                                polang=polang)
         beam = scs.beams[0][0]
-        print(beam)
         hwp_mueller = np.asarray([[1, 0, 0, 0],
-                                  [0, 0, 0, 0],
-                                  [0, 0, 0, 0],
-                                  [0, 0, 0, 0]])
+                                  [0, 1, 0, 0],
+                                  [0, 0, -1, 0],
+                                  [0, 0, 0, -1]])
         beam.hwp_mueller = hwp_mueller
         scs.init_detpair(self.alm, beam, nside_spin=nside,
                                    max_spin=mmax)
@@ -1260,10 +1251,8 @@ class TestTools(unittest.TestCase):
         # Turn on HWP
         scs.set_hwp_mod(mode='continuous', freq=1., start_ang=0)
         scs.rotate_hwp(**chunk)
-        print("Knampf1")
         tod, pix, nside_out, pa, hwp_ang = scs.scan(beam,
-                        return_tod=True, return_point=True, interp=True,  **chunk)
-        print("Knampf2")
+                        return_tod=True, return_point=True, **chunk)
 
         # Construct TOD manually.
         polang = beam.polang


### PR DESCRIPTION
In the current state, this PR replaces most convolutions by calls into ducc0.totalconvolve, and the tests still seem to run OK.

Still missing:
 - the part labeled "old behaviour": I'm not sure whether I should provide this functionality or whether it will be phased out soon anyway.
 - the "s0a2" terms, since they are quite different from all others; I need some more time for these.

Please don't judge the performance and memory consumption of the code yet, I have not been able to do any optimization so far.

Accuracy of the results should be
- comparable to the existing algorithm for "interp=False"
- much better for "interp=True"

Any feedback is apprciated!
