### PR TITLE
replace np.int/np.float by just int/float

### DIFF
--- a/beamconv/scanning.py
+++ b/beamconv/scanning.py
@@ -58,8 +58,8 @@ def wraparound_2pi(x):
 
     '''
 
-    if len(x)==1: n = np.int(x/(2.*pi))
-    if len(x)>1: n = np.int_(x/(2.*pi))
+    if len(x)==1: n = int(x/(2.*pi))
+    if len(x)>1: n = int_(x/(2.*pi))
     arr = x - n * 2.*pi
     return arr
 
@@ -81,10 +81,10 @@ def wraparound_npi(x, n_):
 
     n_ = float(n_)
     if len(x)==1:
-        n_wrap = np.int(x/(n_*pi))
+        n_wrap = int(x/(n_*pi))
         if x<0: n_wrap-=1
     if len(x)>1:
-        n_wrap = np.int_(x/(n_*pi))
+        n_wrap = int(x/(n_*pi))
         ind = np.where((x<0))
         if len(ind[0]) != 0: n_wrap[ind[0]]-=1
     return x-n_wrap*n_*pi

--- a/beamconv/transfer_matrix.py
+++ b/beamconv/transfer_matrix.py
@@ -237,9 +237,9 @@ class transferMatrix(object):
 
         rot    = np.array(((cos(rotation), -1*sin(rotation),0),\
                         (sin(rotation), cos(rotation), 0),\
-                        (0, 0, 1)), dtype=np.complex)
+                        (0, 0, 1)), dtype=np.complex_)
         rotinv = inv(rot)
-        eps    = np.array(((nE**2, 0, 0),(0, nO**2, 0),(0, 0, nO**2)), dtype=np.complex)
+        eps    = np.array(((nE**2, 0, 0),(0, nO**2, 0),(0, 0, nO**2)), dtype=np.complex_)
         roteps = np.dot( rot, np.dot( eps, rotinv))
         rotepsinv = inv(roteps)
         self.dielectric_tensor = roteps
@@ -256,7 +256,7 @@ class transferMatrix(object):
         DenomDOrd = sqrt( cos(thetaO)**2 + sin(thetaO)**2 * sin(chi)**2)
         DOrd      = np.array(( -1*sin(chi)*cos(thetaO), \
                                cos(chi)*cos(thetaO), \
-                               sin(chi)*sin(thetaO)), dtype=np.complex)
+                               sin(chi)*sin(thetaO)), dtype=np.complex_)
         DOrd      = DOrd / DenomDOrd
         self.DOrd = DOrd
         self.EOrd = np.dot(roteps, DOrd)
@@ -266,7 +266,7 @@ class transferMatrix(object):
         DenomDExtra = sqrt( cos(chi)**2 *cos(thetaO)**2 + sin(chi)**2 * cos(thetaO-thetaE)**2)
         DExtra      = np.array(( 1*cos(chi)*cos(thetaO)*cos(thetaE), \
                                  1*sin(chi)*( sin(thetaO)*sin(thetaE) + cos(thetaO)*cos(thetaE)),\
-                                 - cos(chi)*cos(thetaE)*sin(thetaO)), dtype=np.complex)
+                                 - cos(chi)*cos(thetaE)*sin(thetaO)), dtype=np.complex_)
         DExtra      = DExtra / DenomDExtra
         self.DExtra = DExtra
         self.EExtra = np.dot(roteps, DExtra)
@@ -275,7 +275,7 @@ class transferMatrix(object):
         DenomHOrd = sqrt(cos(thetaO)**2 * cos(chi)**2 + sin(chi)**2)
         HOrd      = np.array(( -cos(thetaO)**2 * cos(chi),\
                                -sin(chi),\
-                               cos(thetaO)*sin(thetaO)*cos(chi)), dtype=np.complex)
+                               cos(thetaO)*sin(thetaO)*cos(chi)), dtype=np.complex_)
         HOrd      = HOrd / DenomHOrd
         self.HOrd = HOrd
 
@@ -284,7 +284,7 @@ class transferMatrix(object):
         HExtra      = np.array(( -cos(thetaO-thetaE) * cos(thetaE) * sin(chi),\
                                  1*cos(thetaO)*cos(chi),\
                                  1*cos(thetaO-thetaE) * sin(thetaE) * sin(chi)),\
-                               dtype=np.complex)
+                               dtype=np.complex_)
         HExtra      = HExtra / DenomHExtra
         self.HExtra = HExtra
 
@@ -305,7 +305,7 @@ class transferMatrix(object):
                         (HOrd[1]/nO, HExtra[1]/nE, -1*HOrd[1]/nO, -1*HExtra[1]/nE),\
                         (DOrd[1], DExtra[1], DOrd[1], DExtra[1]),\
                         (-1*HOrd[0]/nO, -1*HExtra[0]/nE, HOrd[0]/nO, HExtra[0]/nE)),\
-                      dtype=np.complex)
+                      dtype=np.complex_)
 
         # Form the matrix relating vII = (Dx,Hy,Dy,-Hx) at interface II to the four
         # D components at the interface in the material. These are formed
@@ -325,13 +325,13 @@ class transferMatrix(object):
         P  = np.array( ((exp(-1*deltaO), 0, 0, 0),\
                         (0, exp(-1*deltaE), 0, 0),\
                         (0, 0, exp(deltaO), 0),\
-                        (0, 0, 0, exp(deltaE))), dtype=np.complex)
+                        (0, 0, 0, exp(deltaE))), dtype=np.complex_)
 
         # Define the conversion matrix from D field components to those of E.
         Psi = np.array( ((rotepsinv[0,0], 0, rotepsinv[0,1], 0),\
                         (0, 1, 0, 0),\
                         (rotepsinv[1,0], 0, rotepsinv[1,1], 0),\
-                        (0, 0, 0, 1)), dtype=np.complex)
+                        (0, 0, 0, 1)), dtype=np.complex_)
 
         # Now compute the transfer matrix as Psi.Phi.inv(Psi.Phi.P)
         self.Phi = Phi
@@ -373,7 +373,7 @@ class stackTransferMatrix(object):
         angles      = stack.angles
 
         self.transfers = []
-        self.totalTransfer = np.eye(4, dtype=np.complex)
+        self.totalTransfer = np.eye(4, dtype=np.complex_)
 
         for layerNum in range(numLayers):
             material      = materials[layerNum]
@@ -431,12 +431,12 @@ def TranToJones(transfer):
     denom = (A+C)*(K+S)-(B+D)*(N+P) # Both matrices share a factor dividing all elements.
 
     # Transmitted Jones matrix.
-    Jtran = np.array(((K+S, -B-D),(-N-P, A+C)), dtype=np.complex) * 2 / denom
+    Jtran = np.array(((K+S, -B-D),(-N-P, A+C)), dtype=np.complex_) * 2 / denom
 
     # Reflected Jones matrix.
     Jref = np.array(( ((C-A)*(K+S)-(D-B)*(N+P), 2*(A*D - C*B)),\
                       (2*(N*S - P*K), (A+C)*(K-S) - (D+B)*(N-P))),\
-                    dtype=np.complex) / denom
+                    dtype=np.complex_) / denom
 
     return Jtran, Jref
 
@@ -452,10 +452,10 @@ def JonesToMueller(jones):
     # Stokes parameters. Note that to match up with Polarized Light by Goldstein,
     # I had to multiply the last Pauli matrix by -1, a change from the Jones et al paper.
     Sigma = []
-    Sigma.append( np.array(( (1,0),(0,1)), dtype=np.complex)) # identity matrix
-    Sigma.append( np.array(( (1,0),(0,-1)), dtype=np.complex))
-    Sigma.append( np.array(( (0,1),(1,0)), dtype=np.complex))
-    Sigma.append( np.array(( (0,-1j),(1j,0)), dtype=np.complex)) # Need to multiply by -1 to change back to normal.
+    Sigma.append( np.array(( (1,0),(0,1)), dtype=np.complex_)) # identity matrix
+    Sigma.append( np.array(( (1,0),(0,-1)), dtype=np.complex_))
+    Sigma.append( np.array(( (0,1),(1,0)), dtype=np.complex_))
+    Sigma.append( np.array(( (0,-1j),(1j,0)), dtype=np.complex_)) # Need to multiply by -1 to change back to normal.
 
     # Now the Mueller matrix elements are given by Mij = 1/2 * Tr(sigma[i]*J*sigma[j]*J^dagger)
     m = np.zeros((4,4), dtype=float)
@@ -698,7 +698,7 @@ def BandAveragedMueller( stack, spectrumFile, minFreq, maxFreq, reflected=False,
 
 def JonesRotation(jones, theta):
 
-    rot = np.array(((cos(theta*deg),-sin(theta*deg)),(sin(theta*deg),cos(theta*deg))),dtype=np.complex)
+    rot = np.array(((cos(theta*deg),-sin(theta*deg)),(sin(theta*deg),cos(theta*deg))),dtype=np.complex_)
 
     return np.dot(rot, np.dot( jones, inv(rot)))
 

--- a/beamconv/transfer_matrix.py
+++ b/beamconv/transfer_matrix.py
@@ -197,7 +197,7 @@ class transferMatrix(object):
         self.nsin           = nsin
         self.rotation       = rotation
 
-        self.optic_axis     = np.array((cos(rotation),sin(rotation),0),dtype=np.float)
+        self.optic_axis     = np.array((cos(rotation),sin(rotation),0),dtype=float)
 
         # Pull quantities that will show up in equations below.
         chi     = rotation
@@ -458,7 +458,7 @@ def JonesToMueller(jones):
     Sigma.append( np.array(( (0,-1j),(1j,0)), dtype=np.complex)) # Need to multiply by -1 to change back to normal.
 
     # Now the Mueller matrix elements are given by Mij = 1/2 * Tr(sigma[i]*J*sigma[j]*J^dagger)
-    m = np.zeros((4,4), dtype=np.float)
+    m = np.zeros((4,4), dtype=float)
 
     for i in range(4):
         for j in range(4):
@@ -556,25 +556,25 @@ def BandAveragedMueller( stack, spectrumFile, minFreq, maxFreq, reflected=False,
     against the detector passband and the spectrum of the source being observed.
     """
 
-    frequencies = minFreq + np.arange(numFreqs, dtype=np.float) * (maxFreq - minFreq)/numFreqs
+    frequencies = minFreq + np.arange(numFreqs, dtype=float) * (maxFreq - minFreq)/numFreqs
 
     # Create arrays to hold the Mueller-matrix elements at each frequency.
-    MuellerII = np.zeros(numFreqs, dtype=np.float)
-    MuellerIU = np.zeros(numFreqs, dtype=np.float)
-    MuellerIQ = np.zeros(numFreqs, dtype=np.float)
-    MuellerIV = np.zeros(numFreqs, dtype=np.float)
-    MuellerQI = np.zeros(numFreqs, dtype=np.float)
-    MuellerQU = np.zeros(numFreqs, dtype=np.float)
-    MuellerQQ = np.zeros(numFreqs, dtype=np.float)
-    MuellerQV = np.zeros(numFreqs, dtype=np.float)
-    MuellerUI = np.zeros(numFreqs, dtype=np.float)
-    MuellerUU = np.zeros(numFreqs, dtype=np.float)
-    MuellerUQ = np.zeros(numFreqs, dtype=np.float)
-    MuellerUV = np.zeros(numFreqs, dtype=np.float)
-    MuellerVI = np.zeros(numFreqs, dtype=np.float)
-    MuellerVQ = np.zeros(numFreqs, dtype=np.float)
-    MuellerVU = np.zeros(numFreqs, dtype=np.float)
-    MuellerVV = np.zeros(numFreqs, dtype=np.float)
+    MuellerII = np.zeros(numFreqs, dtype=float)
+    MuellerIU = np.zeros(numFreqs, dtype=float)
+    MuellerIQ = np.zeros(numFreqs, dtype=float)
+    MuellerIV = np.zeros(numFreqs, dtype=float)
+    MuellerQI = np.zeros(numFreqs, dtype=float)
+    MuellerQU = np.zeros(numFreqs, dtype=float)
+    MuellerQQ = np.zeros(numFreqs, dtype=float)
+    MuellerQV = np.zeros(numFreqs, dtype=float)
+    MuellerUI = np.zeros(numFreqs, dtype=float)
+    MuellerUU = np.zeros(numFreqs, dtype=float)
+    MuellerUQ = np.zeros(numFreqs, dtype=float)
+    MuellerUV = np.zeros(numFreqs, dtype=float)
+    MuellerVI = np.zeros(numFreqs, dtype=float)
+    MuellerVQ = np.zeros(numFreqs, dtype=float)
+    MuellerVU = np.zeros(numFreqs, dtype=float)
+    MuellerVV = np.zeros(numFreqs, dtype=float)
 
     
     # Calculate the Mueller matrix of the stack at each of the frequencies. 
@@ -608,7 +608,7 @@ def BandAveragedMueller( stack, spectrumFile, minFreq, maxFreq, reflected=False,
     # Now read in the spectrum from the file.
     specFile = open( spectrumFile, 'r')
     specText = specFile.readlines()
-    spectrumData = np.zeros((2,len(specText)-2), dtype=np.float)
+    spectrumData = np.zeros((2,len(specText)-2), dtype=float)
 
 
     # Clip the first two lines of the spectrum. These are descriptive text.
@@ -628,7 +628,7 @@ def BandAveragedMueller( stack, spectrumFile, minFreq, maxFreq, reflected=False,
     # need to interpolate the data to the frequencies chosen above.
 
     if passBandFile==False:
-        passBand = np.zeros(numFreqs, dtype=np.float)
+        passBand = np.zeros(numFreqs, dtype=float)
         
         for i in range(numFreqs):
             passBand[i] = 1.0
@@ -636,7 +636,7 @@ def BandAveragedMueller( stack, spectrumFile, minFreq, maxFreq, reflected=False,
     else:
         bandFile = open( passBandFile, 'r')
         bandText = bandFile.readlines()
-        passBandData = np.zeros( (2,len(bandText)-2), dtype=np.float)
+        passBandData = np.zeros( (2,len(bandText)-2), dtype=float)
 
         for j in range(2, len(bandText)):
             freq, band = bandText[j].split()
@@ -691,7 +691,7 @@ def BandAveragedMueller( stack, spectrumFile, minFreq, maxFreq, reflected=False,
          (IntegratedMuellerQI,IntegratedMuellerQQ,IntegratedMuellerQU,IntegratedMuellerQV),\
          (IntegratedMuellerUI,IntegratedMuellerUQ,IntegratedMuellerUU,IntegratedMuellerUV),\
          (IntegratedMuellerVI,IntegratedMuellerVQ,IntegratedMuellerVU,IntegratedMuellerVV)),\
-        dtype=np.float)
+        dtype=float)
 
     return IntegratedMueller
     


### PR DESCRIPTION
This change is necessary when using recent `numpy` releases, since `np.int` and `np.float` have been obsoleted.
